### PR TITLE
feat: add orders pdf report

### DIFF
--- a/pyt_dunamis_v2/Controllers/ReportesController.cs
+++ b/pyt_dunamis_v2/Controllers/ReportesController.cs
@@ -66,6 +66,8 @@ namespace pyt_dunamis_v2.Controllers
         [HttpGet]
         public IActionResult ReportesOrdenesPdf(int? idestado, DateTime? fechaInicio, DateTime? fechaFin)
         {
+            QuestPDF.Settings.License = LicenseType.Community;
+
             var lista = _ordenesLN.ObtenerTodasOrdenes();
 
             if (idestado.HasValue)

--- a/pyt_dunamis_v2/Controllers/ReportesController.cs
+++ b/pyt_dunamis_v2/Controllers/ReportesController.cs
@@ -24,7 +24,7 @@ namespace pyt_dunamis_v2.Controllers
         }
 
         [HttpGet]
-        public IActionResult ReportesOrdenes(int? idestado, DateTime? fecha_visita)
+        public IActionResult ReportesOrdenes(int? idestado, DateTime? fechaInicio, DateTime? fechaFin)
         {
             // Obtener lista de estados para el filtro
             var estados = _catalogoLN.ObtenerCatalogoEstadoOrden();
@@ -37,9 +37,14 @@ namespace pyt_dunamis_v2.Controllers
                 lista = lista.Where(o => o.estado_orden_id_estado_orden == idestado.Value).ToList();
             }
 
-            if (fecha_visita.HasValue)
+            if (fechaInicio.HasValue)
             {
-                lista = lista.Where(o => o.fecha_visita.Date == fecha_visita.Value.Date).ToList();
+                lista = lista.Where(o => o.fecha_visita.Date >= fechaInicio.Value.Date).ToList();
+            }
+
+            if (fechaFin.HasValue)
+            {
+                lista = lista.Where(o => o.fecha_visita.Date <= fechaFin.Value.Date).ToList();
             }
 
             var vm = new OrdenesViewModel
@@ -51,14 +56,15 @@ namespace pyt_dunamis_v2.Controllers
                     Text = e.descripcion_estado,
                     Selected = (idestado.HasValue && e.id_estado_orden == idestado.Value)
                 }).ToList(),
-                fecha_visita = fecha_visita ?? default(DateTime)
+                fechaInicio = fechaInicio,
+                fechaFin = fechaFin
             };
 
             return View(vm);
         }
 
         [HttpGet]
-        public IActionResult ReportesOrdenesPdf(int? idestado, DateTime? fecha_visita)
+        public IActionResult ReportesOrdenesPdf(int? idestado, DateTime? fechaInicio, DateTime? fechaFin)
         {
             var lista = _ordenesLN.ObtenerTodasOrdenes();
 
@@ -67,9 +73,14 @@ namespace pyt_dunamis_v2.Controllers
                 lista = lista.Where(o => o.estado_orden_id_estado_orden == idestado.Value).ToList();
             }
 
-            if (fecha_visita.HasValue)
+            if (fechaInicio.HasValue)
             {
-                lista = lista.Where(o => o.fecha_visita.Date == fecha_visita.Value.Date).ToList();
+                lista = lista.Where(o => o.fecha_visita.Date >= fechaInicio.Value.Date).ToList();
+            }
+
+            if (fechaFin.HasValue)
+            {
+                lista = lista.Where(o => o.fecha_visita.Date <= fechaFin.Value.Date).ToList();
             }
 
             var document = Document.Create(container =>

--- a/pyt_dunamis_v2/Models/OrdenesViewModel.cs
+++ b/pyt_dunamis_v2/Models/OrdenesViewModel.cs
@@ -22,6 +22,9 @@ namespace pyt_dunamis_v2.Models
 
         public int? tipo_puesto_id { get; set; }
 
+        public DateTime? fechaInicio { get; set; }
+        public DateTime? fechaFin { get; set; }
+
         [ValidateNever]
         public List<SelectListItem> TipoEstadoOrden { get; set; }
         [ValidateNever]

--- a/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
+++ b/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
@@ -58,6 +58,10 @@
     </form>
 </div>
 
+<div class="mb-3">
+    <a class="btn btn-success" asp-action="ReportesOrdenesPdf">Descargar PDF</a>
+</div>
+
 <!-- Tabla de historial -->
 <div>
     <table class="table table-bordered table-striped">

--- a/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
+++ b/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
@@ -19,7 +19,7 @@
         <div class="row">
             <div class="col-md-6">
                 <label for="estadoSelect">Filtrar por estado</label>
-                <select id="estadoSelect" name="idestado" class="form-select" onchange="this.form.submit()">
+                <select id="estadoSelect" name="idestado" class="form-select">
                     <option value="">-- Todos los estados --</option>
                     @foreach (var estado in Model.TipoEstadoOrden)
                     {
@@ -32,12 +32,12 @@
 </div> *@
 
 <div class="col-md-12">
-    <form asp-action="ReporteOrdenes" method="get" class="mb-4">
+    <form asp-action="ReportesOrdenes" method="get" class="mb-4">
         <div class="row">
             <!-- Filtro por estado -->
             <div class="col-md-6">
                 <label for="estadoSelect">Filtrar por estado</label>
-                <select id="estadoSelect" name="idestado" class="form-select" onchange="this.form.submit()">
+                <select id="estadoSelect" name="idestado" class="form-select">
                     <option value="">-- Todos los estados --</option>
                     @foreach (var estado in Model.TipoEstadoOrden)
                     {
@@ -50,7 +50,11 @@
             <div class="col-md-6">
                 <label for="fechaInicio">Fecha Inicio</label>
                 <input type="date" id="fechaInicio" name="fechaInicio" class="form-control"
-                       value="@Model.fecha_visita.ToString("yyyy-MM-dd")" />
+                       value="@Model.fechaInicio?.ToString("yyyy-MM-dd")" />
+
+                <label for="fechaFin" class="mt-2">Fecha Final</label>
+                <input type="date" id="fechaFin" name="fechaFin" class="form-control"
+                       value="@Model.fechaFin?.ToString("yyyy-MM-dd")" />
 
                 <button type="submit" class="btn btn-primary mt-3">Filtrar</button>
             </div>
@@ -59,7 +63,10 @@
 </div>
 
 <div class="mb-3">
-    <a class="btn btn-success" asp-action="ReportesOrdenesPdf">Descargar PDF</a>
+    <a class="btn btn-success" asp-action="ReportesOrdenesPdf"
+       asp-route-idestado="@Context.Request.Query["idestado"]"
+       asp-route-fechaInicio="@Model.fechaInicio?.ToString("yyyy-MM-dd")"
+       asp-route-fechaFin="@Model.fechaFin?.ToString("yyyy-MM-dd")">Descargar PDF</a>
 </div>
 
 <!-- Tabla de historial -->

--- a/pyt_dunamis_v2/pyt_dunamis_v2.csproj
+++ b/pyt_dunamis_v2/pyt_dunamis_v2.csproj
@@ -13,7 +13,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
-	 <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.34" />
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.34" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add PDF generation for orders report using QuestPDF
- include download button on ReportesOrdenes view
- reference QuestPDF package

## Testing
- `dotnet build pyt_dunamis_v2.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bf3401fcc8331979979918e0613b4