### PR TITLE
feat: add orders pdf report with date range filter

### DIFF
--- a/pyt_dunamis_v2/Controllers/ReportesController.cs
+++ b/pyt_dunamis_v2/Controllers/ReportesController.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using pyt_dunamis_v2.Helpers;
 using pyt_dunamis_v2.Models;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
 
 namespace pyt_dunamis_v2.Controllers
 {
@@ -21,7 +24,7 @@ namespace pyt_dunamis_v2.Controllers
         }
 
         [HttpGet]
-        public IActionResult ReportesOrdenes(int? idestado, DateTime? fecha_visita)
+        public IActionResult ReportesOrdenes(int? idestado, DateTime? fechaInicio, DateTime? fechaFin)
         {
             // Obtener lista de estados para el filtro
             var estados = _catalogoLN.ObtenerCatalogoEstadoOrden();
@@ -34,9 +37,14 @@ namespace pyt_dunamis_v2.Controllers
                 lista = lista.Where(o => o.estado_orden_id_estado_orden == idestado.Value).ToList();
             }
 
-            if (fecha_visita.HasValue)
+            if (fechaInicio.HasValue)
             {
-                lista = lista.Where(o => o.fecha_visita.Date == fecha_visita.Value.Date).ToList();
+                lista = lista.Where(o => o.fecha_visita.Date >= fechaInicio.Value.Date).ToList();
+            }
+
+            if (fechaFin.HasValue)
+            {
+                lista = lista.Where(o => o.fecha_visita.Date <= fechaFin.Value.Date).ToList();
             }
 
             var vm = new OrdenesViewModel
@@ -48,10 +56,95 @@ namespace pyt_dunamis_v2.Controllers
                     Text = e.descripcion_estado,
                     Selected = (idestado.HasValue && e.id_estado_orden == idestado.Value)
                 }).ToList(),
-                fecha_visita = fecha_visita ?? default(DateTime)
+                fechaInicio = fechaInicio,
+                fechaFin = fechaFin
             };
 
             return View(vm);
+        }
+
+        [HttpGet]
+        public IActionResult ReportesOrdenesPdf(int? idestado, DateTime? fechaInicio, DateTime? fechaFin)
+        {
+            QuestPDF.Settings.License = LicenseType.Community;
+
+            var lista = _ordenesLN.ObtenerTodasOrdenes();
+
+            if (idestado.HasValue)
+            {
+                lista = lista.Where(o => o.estado_orden_id_estado_orden == idestado.Value).ToList();
+            }
+
+            if (fechaInicio.HasValue)
+            {
+                lista = lista.Where(o => o.fecha_visita.Date >= fechaInicio.Value.Date).ToList();
+            }
+
+            if (fechaFin.HasValue)
+            {
+                lista = lista.Where(o => o.fecha_visita.Date <= fechaFin.Value.Date).ToList();
+            }
+
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.A4);
+                    page.Margin(30);
+                    page.DefaultTextStyle(x => x.FontSize(12));
+
+                    page.Header()
+                        .AlignCenter()
+                        .Text("Reporte de órdenes").SemiBold().FontSize(20);
+
+                    page.Content().Table(table =>
+                    {
+                        table.ColumnsDefinition(columns =>
+                        {
+                            columns.ConstantColumn(40);
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Element(CellStyle).Text("N°");
+                            header.Cell().Element(CellStyle).Text("Contrato");
+                            header.Cell().Element(CellStyle).Text("Tipo");
+                            header.Cell().Element(CellStyle).Text("Fecha");
+                            header.Cell().Element(CellStyle).Text("Detalle");
+                            header.Cell().Element(CellStyle).Text("Estado");
+                            header.Cell().Element(CellStyle).Text("Colaborador");
+                            header.Cell().Element(CellStyle).Text("Puesto");
+                        });
+
+                        foreach (var o in lista)
+                        {
+                            table.Cell().Element(CellStyle).Text(o.id_orden.ToString());
+                            table.Cell().Element(CellStyle).Text(o.contrato_cliente);
+                            table.Cell().Element(CellStyle).Text(o.tipo_trabajo);
+                            table.Cell().Element(CellStyle).Text(o.fecha_visita.ToShortDateString());
+                            table.Cell().Element(CellStyle).Text(o.descripcion_trabajo);
+                            table.Cell().Element(CellStyle).Text(o.Estado_orden?.descripcion_estado ?? string.Empty);
+                            table.Cell().Element(CellStyle).Text(o.Colaborador.Persona.nombre + " " + o.Colaborador.Persona.apellido_1);
+                            table.Cell().Element(CellStyle).Text(o.Colaborador.Catalogo_perfil_puesto.descripcion_puesto);
+                        }
+                    });
+                });
+            });
+
+            byte[] pdf = document.GeneratePdf();
+            return File(pdf, "application/pdf", "ReporteOrdenes.pdf");
+
+            static IContainer CellStyle(IContainer container)
+            {
+                return container.Padding(5).Border(1);
+            }
         }
 
         public ActionResult ReportesEmpleados()

--- a/pyt_dunamis_v2/Models/OrdenesViewModel.cs
+++ b/pyt_dunamis_v2/Models/OrdenesViewModel.cs
@@ -22,6 +22,9 @@ namespace pyt_dunamis_v2.Models
 
         public int? tipo_puesto_id { get; set; }
 
+        public DateTime? fechaInicio { get; set; }
+        public DateTime? fechaFin { get; set; }
+
         [ValidateNever]
         public List<SelectListItem> TipoEstadoOrden { get; set; }
         [ValidateNever]

--- a/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
+++ b/pyt_dunamis_v2/Views/Reportes/ReportesOrdenes.cshtml
@@ -19,7 +19,7 @@
         <div class="row">
             <div class="col-md-6">
                 <label for="estadoSelect">Filtrar por estado</label>
-                <select id="estadoSelect" name="idestado" class="form-select" onchange="this.form.submit()">
+                <select id="estadoSelect" name="idestado" class="form-select">
                     <option value="">-- Todos los estados --</option>
                     @foreach (var estado in Model.TipoEstadoOrden)
                     {
@@ -32,12 +32,12 @@
 </div> *@
 
 <div class="col-md-12">
-    <form asp-action="ReporteOrdenes" method="get" class="mb-4">
+    <form asp-action="ReportesOrdenes" method="get" class="mb-4">
         <div class="row">
             <!-- Filtro por estado -->
             <div class="col-md-6">
                 <label for="estadoSelect">Filtrar por estado</label>
-                <select id="estadoSelect" name="idestado" class="form-select" onchange="this.form.submit()">
+                <select id="estadoSelect" name="idestado" class="form-select">
                     <option value="">-- Todos los estados --</option>
                     @foreach (var estado in Model.TipoEstadoOrden)
                     {
@@ -50,12 +50,23 @@
             <div class="col-md-6">
                 <label for="fechaInicio">Fecha Inicio</label>
                 <input type="date" id="fechaInicio" name="fechaInicio" class="form-control"
-                       value="@Model.fecha_visita.ToString("yyyy-MM-dd")" />
+                       value="@Model.fechaInicio?.ToString("yyyy-MM-dd")" />
 
-                <button type="submit" class="btn btn-primary mt-3">Filtrar</button>
+                <label for="fechaFin" class="mt-2">Fecha Final</label>
+                <input type="date" id="fechaFin" name="fechaFin" class="form-control"
+                       value="@Model.fechaFin?.ToString("yyyy-MM-dd")" />
+
+                <button type="submit" class="btn btn-success mt-3">Filtrar</button>
             </div>
         </div>
     </form>
+</div>
+
+<div class="mb-3">
+    <a class="btn btn-success" asp-action="ReportesOrdenesPdf"
+       asp-route-idestado="@Context.Request.Query["idestado"]"
+       asp-route-fechaInicio="@Model.fechaInicio?.ToString("yyyy-MM-dd")"
+       asp-route-fechaFin="@Model.fechaFin?.ToString("yyyy-MM-dd")">Descargar PDF</a>
 </div>
 
 <!-- Tabla de historial -->

--- a/pyt_dunamis_v2/pyt_dunamis_v2.csproj
+++ b/pyt_dunamis_v2/pyt_dunamis_v2.csproj
@@ -13,7 +13,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
-	 <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.34" />
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.34" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add date range filtering to orders report and PDF generation
- extend view model and view to include start and end date inputs
- configure QuestPDF community license to allow PDF downloads
- style the filter button in the orders report view green

## Testing
- `dotnet build pyt_dunamis_v2.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf3401fcc8331979979918e0613b4